### PR TITLE
Update dependencies to fix sec issues in lodash and aws-sdk

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8
+    - image: circleci/node:14
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
-      - run: 
+      - run:
           name: Set NPM authentication.
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run:
@@ -54,6 +54,6 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-    
+
 
 

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "devDependencies": {
     "@types/jest": "29.1.1",
     "coveralls": "3.1.1",
-    "eslint": "6.4.0",
-    "eslint-config-prettier": "2.9.0",
-    "eslint-plugin-prettier": "2.6.0",
+    "eslint": "8.24.0",
+    "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-prettier": "4.2.1",
     "jest": "29.1.1",
-    "prettier": "1.10.2"
+    "prettier": "2.7.1"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "url": "https://github.com/orchestrated-io/serverless-plugin-offline-kinesis-stream/issues"
   },
   "dependencies": {
-    "aws-sdk": "2.238.1",
+    "aws-sdk": "^2.1226.0",
     "kinesis-readable": "1.2.0",
-    "lodash": "~>4.17.11",
+    "lodash": "^4.17.21",
     "path": "0.12.7"
   },
   "devDependencies": {
-    "@types/jest": "22.1.1",
-    "coveralls": "3.0.1",
+    "@types/jest": "29.1.1",
+    "coveralls": "3.1.1",
     "eslint": "6.4.0",
     "eslint-config-prettier": "2.9.0",
     "eslint-plugin-prettier": "2.6.0",
-    "jest": "22.4.3",
+    "jest": "29.1.1",
     "prettier": "1.10.2"
   },
   "license": "MIT"

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,8 @@ const readableStream = require('kinesis-readable');
 
 function toLambdaEvent(messages) {
   return messages.map((message) => {
-    const {
-      SequenceNumber,
-      ApproximateArrivalTimestamp,
-      PartitionKey,
-      Data
-    } = message;
+    const { SequenceNumber, ApproximateArrivalTimestamp, PartitionKey, Data } =
+      message;
     return {
       eventID: `shardId-000000000000:${SequenceNumber}`,
       eventVersion: '1.0',
@@ -21,13 +17,13 @@ function toLambdaEvent(messages) {
         partitionKey: PartitionKey,
         data: Data.toString('base64'),
         kinesisSchemaVersion: '1.0',
-        sequenceNumber: SequenceNumber
+        sequenceNumber: SequenceNumber,
       },
       invokeIdentityArn: 'arn:aws:iam::EXAMPLE',
       eventName: 'aws:kinesis:record',
       eventSourceARN: 'arn:aws:kinesis:EXAMPLE',
       eventSource: 'aws:kinesis',
-      awsRegion: 'ap-southeast-2'
+      awsRegion: 'ap-southeast-2',
     };
   });
 }
@@ -54,21 +50,18 @@ class ServerlessPluginOfflineKinesisStream {
       functions: functions.map((functionName) => {
         const fn = _.get(serverless.service.functions, functionName);
         return fn && this.createHandler(fn);
-      })
+      }),
     }));
     this.provider = 'aws';
     this.commands = {};
     this.hooks = {
-      'before:offline:start:init': this.startReadableStreams.bind(this)
+      'before:offline:start:init': this.startReadableStreams.bind(this),
     };
   }
 
   createHandler(fn) {
     const handler = require(this.location + '/' + fn.handler.split('.')[0])[
-      fn.handler
-        .split('/')
-        .pop()
-        .split('.')[1]
+      fn.handler.split('/').pop().split('.')[1]
     ];
     return (event, context = {}) => handler(event, context);
   }
@@ -77,7 +70,7 @@ class ServerlessPluginOfflineKinesisStream {
     const self = this;
     const {
       config: { host: hostname, port, region = 'localhost' } = {},
-      streams
+      streams,
     } = self;
 
     const endpoint = new AWS.Endpoint(`http://${hostname}:${port}`);
@@ -86,12 +79,12 @@ class ServerlessPluginOfflineKinesisStream {
       const client = new AWS.Kinesis({
         endpoint,
         region,
-        params: { StreamName: streamName }
+        params: { StreamName: streamName },
       });
 
       const options = {
         iterator: 'LATEST',
-        limit: 1
+        limit: 1,
       };
 
       const readable = readableStream(client, options);

--- a/test/handler.js
+++ b/test/handler.js
@@ -1,3 +1,3 @@
 module.exports = {
-  funtionA() {}
+  funtionA() {},
 };

--- a/test/test.js
+++ b/test/test.js
@@ -6,17 +6,17 @@ const ServerlessPluginOfflineKinesisStream = require('../src');
 const handler = require('./handler');
 const serverless = {
   config: {
-    servicePath: '../test'
+    servicePath: '../test',
   },
   service: {
     custom: {
       'serverless-offline': {},
       kinesisStream: {
-        streams: [{ table: 'table-name', functions: ['funtionA'] }]
+        streams: [{ table: 'table-name', functions: ['funtionA'] }],
       },
-      functions: { funtionA: { handler: 'handler.funtionA' } }
-    }
-  }
+      functions: { funtionA: { handler: 'handler.funtionA' } },
+    },
+  },
 };
 const options = {};
 
@@ -27,7 +27,7 @@ describe('Serverless Plugin Offline Kinesis Stream', () => {
       options
     );
     expect(plugin.hooks).toEqual({
-      'before:offline:start:init': expect.any(Function)
+      'before:offline:start:init': expect.any(Function),
     });
   });
 


### PR DESCRIPTION
Hi, 
thank you for creating this plugin. We are using it in our projects together with `serverless-plugin-offline-dynamodb-stream`. 

With this PR i updated the dependencies to fix dependabot security alerts caused by the outdated `lodash` and `aws-sdk` version it is using.

To get it working i also needed to update the node version because i got this error: ` SecurityError: localStorage is not available for opaque origins`. I picked node14 because that is the oldest one supported by AWS lambdas now and the one you are using for `serverless-plugin-offline-dynamodb-stream`.

I also updated the dev dependencies and applied a `eslint --fix` to round it up.

Please have a look and i would be very happy if you would create a new release with that.
